### PR TITLE
Uncouple Manager from PacketHandler, Locator

### DIFF
--- a/src/Peer/Factory.php
+++ b/src/Peer/Factory.php
@@ -119,14 +119,12 @@ class Factory
     }
 
     /**
-     * @param Locator $locator
-     * @param PacketHandler $handler
      * @param bool|false $shouldRelay
      * @return Manager
      */
-    public function getManager(Locator $locator, PacketHandler $handler, $shouldRelay = false)
+    public function getManager($shouldRelay = false)
     {
-        return new Manager($this, $locator, $handler, $shouldRelay);
+        return new Manager($this, $shouldRelay);
     }
 
     /**

--- a/src/Peer/Listener.php
+++ b/src/Peer/Listener.php
@@ -3,6 +3,7 @@
 namespace BitWasp\Bitcoin\Networking\Peer;
 
 use BitWasp\Bitcoin\Networking\Structure\NetworkAddressInterface;
+use BitWasp\Bitcoin\Networking\Messages\Factory as MessageFactory;
 use Evenement\EventEmitter;
 use React\EventLoop\LoopInterface;
 use React\Socket\Connection;
@@ -21,9 +22,9 @@ class Listener extends EventEmitter
     private $loop;
 
     /**
-     * @var \BitWasp\Bitcoin\Networking\Messages\Factory
+     * @var MessageFactory
      */
-    private $msgs;
+    private $messageFactory;
 
     /**
      * @var Server
@@ -32,18 +33,18 @@ class Listener extends EventEmitter
 
     /**
      * @param NetworkAddressInterface $localAddr
-     * @param \BitWasp\Bitcoin\Networking\Messages\Factory $messageFactory
+     * @param MessageFactory $messageFactory
      * @param Server $server
      * @param LoopInterface $loop
      */
     public function __construct(
         NetworkAddressInterface $localAddr,
-        \BitWasp\Bitcoin\Networking\Messages\Factory $messageFactory,
+        MessageFactory $messageFactory,
         Server $server,
         LoopInterface $loop
     ) {
         $this->local = $localAddr;
-        $this->msgs = $messageFactory;
+        $this->messageFactory = $messageFactory;
         $this->server = $server;
         $this->loop = $loop;
 
@@ -57,7 +58,7 @@ class Listener extends EventEmitter
     {
         return new Peer(
             $this->local,
-            $this->msgs,
+            $this->messageFactory,
             $this->loop
         );
     }
@@ -72,7 +73,7 @@ class Listener extends EventEmitter
             ->getPeer()
             ->inboundConnection($connection)
             ->then(
-                function (Peer $peer) use (&$deferred) {
+                function (Peer $peer) {
                     $this->emit('connection', [$peer]);
                 }
             );

--- a/src/Peer/Locator.php
+++ b/src/Peer/Locator.php
@@ -37,8 +37,10 @@ class Locator
     {
         $seeds = [
             'seed.bitcoin.sipa.be',
+            'dnsseed.bluematt.me',
             'dnsseed.bitcoin.dashjr.org',
             'seed.bitcoinstats.com',
+            'bitseed.xf2.org',
             'seed.bitnodes.io',
             "seed.bitcoin.jonasschnelli.ch"
         ];
@@ -53,7 +55,7 @@ class Locator
     /**
      * Connect to $numSeeds DNS seeds
      *
-     * @param $numSeeds
+     * @param int $numSeeds
      * @return \React\Promise\Promise|\React\Promise\PromiseInterface
      */
     public function queryDnsSeeds($numSeeds = 1)
@@ -85,6 +87,8 @@ class Locator
             ->promise()
             ->then(
                 function (array $vPeerVAddrs) {
+                    shuffle($vPeerVAddrs);
+
                     /** @var NetworkAddressInterface[] $addresses */
                     $addresses = [];
                     array_map(

--- a/src/Peer/PacketHandler.php
+++ b/src/Peer/PacketHandler.php
@@ -9,7 +9,6 @@ use Evenement\EventEmitter;
 
 class PacketHandler extends EventEmitter
 {
-
     // listens for:
     // outbound, inbound
 

--- a/src/Peer/Peer.php
+++ b/src/Peer/Peer.php
@@ -74,21 +74,6 @@ class Peer extends EventEmitter
     /**
      * @var int
      */
-    private $pingInterval = 600;
-
-    /**
-     * @var int
-     */
-    private $maxMissedPings = 5;
-
-    /**
-     * @var int
-     */
-    private $missedPings = 0;
-
-    /**
-     * @var int
-     */
     private $lastPongTime;
 
     /**

--- a/tests/Peer/FactoryTest.php
+++ b/tests/Peer/FactoryTest.php
@@ -50,7 +50,7 @@ class FactoryTest extends AbstractTestCase
         $handler = $factory->getPacketHandler();
         $this->assertInstanceOf($this->handlerType, $handler);
 
-        $manager = $factory->getManager($locator, $handler);
+        $manager = $factory->getManager();
         $this->assertInstanceOf($this->managerType, $manager);
 
     }


### PR DESCRIPTION
PacketHandler and Locator were required in Managers constructor, which generally made things awkward. To try keep things simple, I've removed these requirements in favor of passing them in respective register* functions. 