### PR TITLE
Added close event notification

### DIFF
--- a/src/Peer/Peer.php
+++ b/src/Peer/Peer.php
@@ -361,6 +361,7 @@ class Peer extends EventEmitter
      */
     public function close()
     {
+        $this->emit('close', [$this]);
         $this->stream->end();
         $this->removeAllListeners();
     }


### PR DESCRIPTION
When a peer disconnects, send an event so an appropriate action such as a reconnection can be handled.