### PR TITLE
Support witness

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     }
   },
   "require": {
-    "bitwasp/bitcoin": "~0.0.26",
+    "bitwasp/bitcoin": "~0.0.27",
     "react/socket-client": "~0.5",
     "react/socket": "~0.4",
     "react/dns": "~0.4",

--- a/examples/peer.locator.php
+++ b/examples/peer.locator.php
@@ -2,17 +2,18 @@
 
 require "../vendor/autoload.php";
 
-use BitWasp\Bitcoin\Networking\Peer\Peer;
-use BitWasp\Bitcoin\Networking\Peer\Locator;
-use BitWasp\Bitcoin\Networking\Peer\Connector;
+use BitWasp\Bitcoin\Networking\DnsSeeds\MainNetDnsSeeds;
 use BitWasp\Bitcoin\Networking\Peer\ConnectionParams;
+use BitWasp\Bitcoin\Networking\Peer\Connector;
+use BitWasp\Bitcoin\Networking\Peer\Locator;
+use BitWasp\Bitcoin\Networking\Peer\Peer;
 
 $loop = React\EventLoop\Factory::create();
 $factory = new \BitWasp\Bitcoin\Networking\Factory($loop);
 $dns = $factory->getDns();
 $msgs = $factory->getMessages();
 
-$locator = new Locator($dns);
+$locator = new Locator(new MainNetDnsSeeds(), $dns);
 $params = new ConnectionParams();
 $connector = new Connector($msgs, $params, $loop, $dns);
 

--- a/examples/peer.manager.php
+++ b/examples/peer.manager.php
@@ -2,19 +2,18 @@
 
 require "../vendor/autoload.php";
 
+use BitWasp\Bitcoin\Networking\DnsSeeds\MainNetDnsSeeds;
+use BitWasp\Bitcoin\Networking\Peer\ConnectionParams;
+use BitWasp\Bitcoin\Networking\Peer\Connector;
 use BitWasp\Bitcoin\Networking\Peer\Locator;
 use BitWasp\Bitcoin\Networking\Peer\Manager;
-use BitWasp\Bitcoin\Networking\Peer\Connector;
-use BitWasp\Bitcoin\Networking\Peer\ConnectionParams;
-
 
 $loop = React\EventLoop\Factory::create();
 $factory = new \BitWasp\Bitcoin\Networking\Factory($loop);
 $dns = $factory->getDns();
 $msgs = $factory->getMessages();
 
-$locator = new Locator($dns);
-$params = new ConnectionParams();
+$locator = new Locator(new MainNetDnsSeeds(), $dns);$params = new ConnectionParams();
 $connector = new Connector($msgs, $params, $loop, $dns);
 $manager = new Manager($connector);
 

--- a/examples/peer.txrelay.php
+++ b/examples/peer.txrelay.php
@@ -3,19 +3,20 @@
 require "../vendor/autoload.php";
 
 
-use BitWasp\Bitcoin\Networking\Peer\Peer;
+use BitWasp\Bitcoin\Networking\DnsSeeds\MainNetDnsSeeds;
+use BitWasp\Bitcoin\Networking\Messages\Inv;
+use BitWasp\Bitcoin\Networking\Peer\ConnectionParams;
+use BitWasp\Bitcoin\Networking\Peer\Connector;
 use BitWasp\Bitcoin\Networking\Peer\Locator;
 use BitWasp\Bitcoin\Networking\Peer\Manager;
-use BitWasp\Bitcoin\Networking\Peer\Connector;
-use BitWasp\Bitcoin\Networking\Peer\ConnectionParams;
-use BitWasp\Bitcoin\Networking\Messages\Inv;
+use BitWasp\Bitcoin\Networking\Peer\Peer;
 
 $loop = React\EventLoop\Factory::create();
 $factory = new \BitWasp\Bitcoin\Networking\Factory($loop);
 $dns = $factory->getDns();
 $msgs = $factory->getMessages();
 
-$locator = new Locator($dns);
+$locator = new Locator(new MainNetDnsSeeds(), $dns);
 $params = new ConnectionParams();
 $params->requestTxRelay();
 

--- a/examples/peer.version.php
+++ b/examples/peer.version.php
@@ -2,21 +2,22 @@
 
 require_once "../vendor/autoload.php";
 
-use BitWasp\Bitcoin\Networking\Ip\Ipv4;
-use React\Promise\Deferred;
+use BitWasp\Bitcoin\Networking\DnsSeeds\MainNetDnsSeeds;
 use BitWasp\Bitcoin\Networking\Factory;
-use BitWasp\Bitcoin\Networking\Peer\Peer;
-use BitWasp\Bitcoin\Networking\Peer\Locator;
+use BitWasp\Bitcoin\Networking\Ip\Ipv4;
+use BitWasp\Bitcoin\Networking\Messages\Version;
 use BitWasp\Bitcoin\Networking\Peer\ConnectionParams;
 use BitWasp\Bitcoin\Networking\Peer\Connector;
-use BitWasp\Bitcoin\Networking\Messages\Version;
+use BitWasp\Bitcoin\Networking\Peer\Locator;
+use BitWasp\Bitcoin\Networking\Peer\Peer;
+use React\Promise\Deferred;
 
 $loop = React\EventLoop\Factory::create();
 $factory = new Factory($loop);
 $dns = $factory->getDns();
 $msgs = $factory->getMessages();
 
-$locator = new Locator($dns);
+$locator = new Locator(new MainNetDnsSeeds(), $dns);
 $params = new ConnectionParams();
 $connector = new Connector($msgs, $params, $loop, $dns);
 

--- a/examples/pushtx.php
+++ b/examples/pushtx.php
@@ -55,6 +55,6 @@ $onConnect = function (Peer $peer) use ($onGetData, $hash) {
 };
 
 $locator->queryDnsSeeds()->then([$manager, 'connectNextPeer']);
-//$manager->connect(new NetworkAddress(0, new Ipv4('5.153.50.115'), 18333))->then($onConnect);
+//$manager->connect(new NetworkAddress(0, new Ipv4('ip address'), 18333))->then($onConnect);
 
 $loop->run();

--- a/examples/pushtx.php
+++ b/examples/pushtx.php
@@ -1,0 +1,60 @@
+<?php
+require_once "../vendor/autoload.php";
+use BitWasp\Bitcoin\Bitcoin;
+use BitWasp\Bitcoin\Networking\Ip\Ipv4;
+use BitWasp\Bitcoin\Networking\Structure\NetworkAddress;
+use BitWasp\Bitcoin\Networking\Message;
+use BitWasp\Bitcoin\Networking\Messages\GetData;
+use BitWasp\Bitcoin\Networking\Peer\ConnectionParams;
+use BitWasp\Bitcoin\Networking\Peer\Connector;
+use BitWasp\Bitcoin\Networking\Peer\Locator;
+use BitWasp\Bitcoin\Networking\Peer\Peer;
+use BitWasp\Bitcoin\Networking\Services;
+use BitWasp\Bitcoin\Networking\Structure\Inventory;
+use BitWasp\Bitcoin\Transaction\TransactionFactory;
+
+$network = \BitWasp\Bitcoin\Network\NetworkFactory::bitcoinTestnet();
+Bitcoin::setNetwork($network);
+$transaction = TransactionFactory::fromHex('01000000000101f15a2db447e8316e9f20073ab8bdeac53df1a53d415fbd41e73929699b889e7a0000000017160014fb459699ce9ca78de6d0790121dfb215883acb64ffffffff0100111024010000001976a914fb459699ce9ca78de6d0790121dfb215883acb6488ac02483045022100c5feadba5fbcc28afb940c7ee664bba81830f19a5407ae49cf75f565534b149702200a7c2b6b1b5846a37c434ffe0cae168d6b797de9087a21176f2c9ef6fa9f47aa014104b848ab6ac853cd69baaa750c70eb352ebeadb07da0ff5bbd642cb285895ee43f2889dd12642ca0ff9b2489bd82d4d5ca287c4ebdf509f1bcd02d6fa720542e2900000000');
+
+$dnsseeds = new \BitWasp\Bitcoin\Networking\DnsSeeds\TestNetDnsSeeds();
+
+// Check for witnesses. If they are found, we increase the counter, eventually checking whether it equals zero.
+$isWitness = (array_reduce($transaction->getWitnesses()->all(), function ($counter, \BitWasp\Bitcoin\Script\ScriptWitnessInterface $wit) {
+        return $wit->isNull() ? $counter : $counter + 1;
+    }, 0) !== 0);
+
+$hash = $isWitness ? $transaction->getTxId() : $transaction->getWitnessTxId();
+
+$loop = React\EventLoop\Factory::create();
+$factory = new \BitWasp\Bitcoin\Networking\Factory($loop, $network);
+$dns = $factory->getDns();
+$msgs = $factory->getMessages();
+
+$locator = new Locator($dnsseeds, $dns);
+$params = new ConnectionParams();
+$params->setLocalServices(Services::NETWORK | Services::WITNESS);
+$params->setRequiredServices(Services::NETWORK | Services::WITNESS);
+
+$connector = new Connector($msgs, $params, $loop, $dns);
+$manager = new \BitWasp\Bitcoin\Networking\Peer\Manager($connector);
+
+$onGetData = function (Peer $peer, GetData $data) use ($hash, $transaction, $loop) {
+    foreach ($data->getItems() as $inv) {
+        if ($inv->getHash()->equals($hash)) {
+            echo "Peer requested tx\n";
+            $peer->tx($transaction);
+            //$loop->stop();
+        }
+    }
+};
+
+$onConnect = function (Peer $peer) use ($onGetData, $hash) {
+    $peer->on(Message::GETDATA, $onGetData);
+    $peer->inv([Inventory::tx($hash)]);
+};
+
+$locator->queryDnsSeeds()->then([$manager, 'connectNextPeer']);
+//$manager->connect(new NetworkAddress(0, new Ipv4('5.153.50.115'), 18333))->then($onConnect);
+
+$loop->run();

--- a/src/DnsSeeds/DnsSeedList.php
+++ b/src/DnsSeeds/DnsSeedList.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace BitWasp\Bitcoin\Networking\DnsSeeds;
+
+
+class DnsSeedList
+{
+    /**
+     * @var array
+     */
+    private $seeds = [];
+
+    /**
+     * DnsSeedList constructor.
+     * @param array $seeds
+     */
+    public function __construct(array $seeds)
+    {
+        $this->seeds = $seeds;
+    }
+
+    /**
+     * @param string $host
+     * @return $this
+     */
+    public function addHost($host)
+    {
+        $this->seeds[] = $host;
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getHosts()
+    {
+        return $this->seeds;
+    }
+}

--- a/src/DnsSeeds/DnsSeedList.php
+++ b/src/DnsSeeds/DnsSeedList.php
@@ -2,7 +2,6 @@
 
 namespace BitWasp\Bitcoin\Networking\DnsSeeds;
 
-
 class DnsSeedList
 {
     /**

--- a/src/DnsSeeds/MainNetDnsSeeds.php
+++ b/src/DnsSeeds/MainNetDnsSeeds.php
@@ -1,0 +1,21 @@
+<?php
+
+
+namespace BitWasp\Bitcoin\Networking\DnsSeeds;
+
+
+class MainNetDnsSeeds extends DnsSeedList
+{
+    public function __construct()
+    {
+        parent::__construct([
+            'seed.bitcoin.sipa.be',
+            'dnsseed.bluematt.me',
+            'dnsseed.bitcoin.dashjr.org',
+            'seed.bitcoinstats.com',
+            'bitseed.xf2.org',
+            'seed.bitnodes.io',
+            "seed.bitcoin.jonasschnelli.ch"
+        ]);
+    }
+}

--- a/src/DnsSeeds/MainNetDnsSeeds.php
+++ b/src/DnsSeeds/MainNetDnsSeeds.php
@@ -3,7 +3,6 @@
 
 namespace BitWasp\Bitcoin\Networking\DnsSeeds;
 
-
 class MainNetDnsSeeds extends DnsSeedList
 {
     public function __construct()

--- a/src/DnsSeeds/TestNetDnsSeeds.php
+++ b/src/DnsSeeds/TestNetDnsSeeds.php
@@ -3,7 +3,6 @@
 
 namespace BitWasp\Bitcoin\Networking\DnsSeeds;
 
-
 class TestNetDnsSeeds extends DnsSeedList
 {
     public function __construct()

--- a/src/DnsSeeds/TestNetDnsSeeds.php
+++ b/src/DnsSeeds/TestNetDnsSeeds.php
@@ -1,0 +1,18 @@
+<?php
+
+
+namespace BitWasp\Bitcoin\Networking\DnsSeeds;
+
+
+class TestNetDnsSeeds extends DnsSeedList
+{
+    public function __construct()
+    {
+        parent::__construct([
+            'testnet-seed.bitcoin.jonasschnelli.ch',
+            'seed.tbtc.petertodd.org',
+            'testnet-seed.bluematt.me',
+            'testnet-seed.bitcoin.schildbach.de'
+        ]);
+    }
+}

--- a/src/GetDataType.php
+++ b/src/GetDataType.php
@@ -2,7 +2,6 @@
 
 namespace BitWasp\Bitcoin\Networking;
 
-
 class GetDataType
 {
     // Invs use TX / block

--- a/src/GetDataType.php
+++ b/src/GetDataType.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace BitWasp\Bitcoin\Networking;
+
+
+class GetDataType
+{
+    // Invs use TX / block
+    const UNDEFINED = 0;
+    const MSG_TX = 1;
+    const MSG_BLOCK = 2;
+    const MSG_TYPE_MAX = self::MSG_BLOCK;
+
+    // The following types can only be used in a getdata:
+    const MSG_FILTERED_BLOCK = 3;
+    const MSG_COMPACT_BLOCK = 4;
+
+    // Witness types
+    const MSG_WITNESS_BLOCK = self::MSG_BLOCK | Protocol::MSG_WITNESS_FLAG;
+    const MSG_WITNESS_TX = self::MSG_TX | Protocol::MSG_WITNESS_FLAG;
+    const MSG_WITNESS_FILTERED_BLOCK = self::MSG_FILTERED_BLOCK | Protocol::MSG_WITNESS_FLAG;
+}

--- a/src/Peer/ConnectionParams.php
+++ b/src/Peer/ConnectionParams.php
@@ -66,6 +66,11 @@ class ConnectionParams
     private $userAgent;
 
     /**
+     * @var int
+     */
+    private $requiredServices = 0;
+
+    /**
      * @param bool $optRelay
      * @return $this
      */
@@ -162,7 +167,25 @@ class ConnectionParams
     }
 
     /**
-     * @param $string
+     * @param int $services
+     * @return $this
+     */
+    public function setRequiredServices($services)
+    {
+        $this->requiredServices = $services;
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getRequiredServices()
+    {
+        return $this->requiredServices;
+    }
+
+    /**
+     * @param string $string
      * @return $this
      */
     public function setUserAgent($string)

--- a/src/Peer/Locator.php
+++ b/src/Peer/Locator.php
@@ -2,6 +2,7 @@
 
 namespace BitWasp\Bitcoin\Networking\Peer;
 
+use BitWasp\Bitcoin\Networking\DnsSeeds\DnsSeedList;
 use BitWasp\Bitcoin\Networking\Ip\Ipv4;
 use BitWasp\Bitcoin\Networking\Services;
 use BitWasp\Bitcoin\Networking\Structure\NetworkAddress;
@@ -18,15 +19,23 @@ class Locator
     private $dns;
 
     /**
+     * @var DnsSeedList
+     */
+    private $seeds;
+
+    /**
      * @var NetworkAddressInterface[]
      */
     private $knownAddresses = [];
 
     /**
+     * Locator constructor.
+     * @param DnsSeedList $list
      * @param Resolver $dns
      */
-    public function __construct(Resolver $dns)
+    public function __construct(DnsSeedList $list, Resolver $dns)
     {
+        $this->seeds = $list;
         $this->dns = $dns;
     }
 
@@ -64,7 +73,7 @@ class Locator
         $peerList = new Deferred();
 
         // Take $numSeeds
-        $seedHosts = self::dnsSeedHosts();
+        $seedHosts = $this->seeds->getHosts();
         $seeds = array_slice($seedHosts, 0, min($numSeeds, count($seedHosts)));
 
         // Connect to $numSeeds peers

--- a/src/Peer/Peer.php
+++ b/src/Peer/Peer.php
@@ -215,8 +215,16 @@ class Peer extends EventEmitter
     public function outboundHandshake(NetworkAddressInterface $remotePeer, ConnectionParams $params)
     {
         $deferred = new Deferred();
+        
+        $awaitVersion = true;
+        $this->stream->on('close', function () use (&$awaitVersion, $deferred) {
+            if ($awaitVersion) {
+                $awaitVersion = false;
+                $deferred->reject('peer disconnected');
+            }
+        });
 
-        $this->on(Message::VERSION, function (Peer $peer, Version $version) {
+        $this->on(Message::VERSION, function (Peer $peer, Version $version) use ($params) {
             $this->remoteVersion = $version;
             $this->verack();
         });

--- a/src/Protocol.php
+++ b/src/Protocol.php
@@ -11,4 +11,7 @@ class Protocol
     const MEMPOOL_GD_VERSION = 60002;
     const NO_BLOOM_VERSION = 70011;
     const SENDHEADERS_VERSION = 70012;
+
+    const MSG_WITNESS_FLAG = 1 << 30;
+    const MSG_TYPE_MASK = 0xffffffff >> 2;
 }

--- a/src/Services.php
+++ b/src/Services.php
@@ -5,7 +5,8 @@ namespace BitWasp\Bitcoin\Networking;
 class Services
 {
     const NONE = 0;
-    const NETWORK = 1;
-    const GETUTXO = 2;
-    const BLOOM = 4;
+    const NETWORK = 1 << 0;
+    const GETUTXO = 1 << 1;
+    const BLOOM = 1 << 2;
+    const WITNESS = 1 << 3;
 }

--- a/tests/Peer/LocatorTest.php
+++ b/tests/Peer/LocatorTest.php
@@ -2,27 +2,20 @@
 
 namespace BitWasp\Bitcoin\Tests\Networking\Peer;
 
+use BitWasp\Bitcoin\Networking\DnsSeeds\MainNetDnsSeeds;
 use BitWasp\Bitcoin\Networking\Peer\Locator;
 use BitWasp\Bitcoin\Tests\Networking\AbstractTestCase;
 
 class LocatorTest extends AbstractTestCase
 {
-    public function testSeedHosts()
-    {
-        $hosts = Locator::dnsSeedHosts(false);
-        $hostsRandom = Locator::dnsSeedHosts();
-        $this->assertInternalType('array', $hosts);
-        $this->assertInternalType('array', $hostsRandom);
 
-        $this->assertNotEquals($hosts, $hostsRandom);
-    }
 
     public function testQuerySeeds()
     {
         $loop = new \React\EventLoop\StreamSelectLoop();
         $factory = new \BitWasp\Bitcoin\Networking\Factory($loop);
 
-        $locator = new Locator($factory->getDns());
+        $locator = new Locator(new MainNetDnsSeeds(), $factory->getDns());
         $foundHosts = null;
         $locator->queryDnsSeeds()->then(function (Locator $locator) use (&$foundHosts) {
             $foundHosts = $locator->getKnownAddresses();
@@ -42,7 +35,7 @@ class LocatorTest extends AbstractTestCase
         $loop = new \React\EventLoop\StreamSelectLoop();
         $factory = new \BitWasp\Bitcoin\Networking\Factory($loop);
 
-        $locator = new Locator($factory->getDns());
+        $locator = new Locator(new MainNetDnsSeeds(), $factory->getDns());
         $locator->popAddress();
     }
 }

--- a/tests/Peer/ManagerTest.php
+++ b/tests/Peer/ManagerTest.php
@@ -2,17 +2,18 @@
 
 namespace BitWasp\Bitcoin\Tests\Networking\Peer;
 
+use BitWasp\Bitcoin\Networking\DnsSeeds\MainNetDnsSeeds;
+use BitWasp\Bitcoin\Networking\Factory as NetworkFactory;
 use BitWasp\Bitcoin\Networking\Ip\Ipv4;
 use BitWasp\Bitcoin\Networking\Peer\ConnectionParams;
+use BitWasp\Bitcoin\Networking\Peer\Connector;
 use BitWasp\Bitcoin\Networking\Peer\Listener;
 use BitWasp\Bitcoin\Networking\Peer\Locator;
 use BitWasp\Bitcoin\Networking\Peer\Manager;
-use BitWasp\Bitcoin\Networking\Peer\Connector;
 use BitWasp\Bitcoin\Networking\Peer\Peer;
 use BitWasp\Bitcoin\Tests\Networking\AbstractTestCase;
-use React\Promise\Deferred;
 use React\EventLoop\StreamSelectLoop;
-use BitWasp\Bitcoin\Networking\Factory as NetworkFactory;
+use React\Promise\Deferred;
 use React\Socket\Server;
 
 class ManagerTest extends AbstractTestCase
@@ -22,7 +23,7 @@ class ManagerTest extends AbstractTestCase
         $loop = new StreamSelectLoop();
         $factory = new NetworkFactory($loop);
         $dns = $factory->getDns();
-        $locator = new Locator($dns);
+        $locator = new Locator(new MainNetDnsSeeds(), $dns);
         $connector = new Connector($factory->getMessages(), new ConnectionParams(), $loop, $dns);
         $manager = new Manager($connector);
 


### PR DESCRIPTION
 - Adds witness service constant
 - Locator now takes a DnsSeedList
 - Connector can enforce required services, if they are set on ConnectionParams.
 - Adds an example of searching DNS seeds for a suitable host to broadcast a segwit transaction